### PR TITLE
SUP-12. PVC-CDAP-Pods.

### DIFF
--- a/cdap-kubernetes/src/main/java/io/cdap/cdap/master/environment/k8s/KubeMasterEnvironment.java
+++ b/cdap-kubernetes/src/main/java/io/cdap/cdap/master/environment/k8s/KubeMasterEnvironment.java
@@ -231,7 +231,7 @@ public class KubeMasterEnvironment implements MasterEnvironment {
   private long workloadIdentityServiceAccountTokenTTLSeconds;
   private String programCpuMultiplier;
   private String cdapInstallNamespace;
-  private Set<String> customVolumePrefix;
+  private Set<String> customVolumePrefixes;
 
   public KubeMasterEnvironment() {
     gson = new Gson();
@@ -250,7 +250,7 @@ public class KubeMasterEnvironment implements MasterEnvironment {
     podUidFile = new File(podInfoDir, conf.getOrDefault(POD_UID_FILE, DEFAULT_POD_UID_FILE));
     podNamespaceFile = new File(podInfoDir, conf.getOrDefault(POD_NAMESPACE_FILE, DEFAULT_POD_NAMESPACE_FILE));
     workloadIdentityEnabled = Boolean.parseBoolean(conf.get(WORKLOAD_IDENTITY_ENABLED));
-    prepareCustomVolumePrefix(conf.get(POD_ADDITIONAL_CUSTOM_VOLUME_PREFIXES));
+    prepareCustomVolumePrefixes(conf.get(POD_ADDITIONAL_CUSTOM_VOLUME_PREFIXES));
     String workloadIdentityProvider = null;
     if (workloadIdentityEnabled) {
       // Validate all workload identity configurations are set
@@ -587,7 +587,7 @@ public class KubeMasterEnvironment implements MasterEnvironment {
    * Returns {@code true} if the given volume name is prefixed with the custom volume mapping from the CRD.
    */
   private boolean isCustomVolumePrefix(String name) {
-    return customVolumePrefix.stream().anyMatch(name::startsWith);
+    return customVolumePrefixes.stream().anyMatch(name::startsWith);
   }
 
   /**
@@ -875,11 +875,11 @@ public class KubeMasterEnvironment implements MasterEnvironment {
     return new PodWatcherThread(podInfo.getNamespace(), labelSelector);
   }
 
-  private void prepareCustomVolumePrefix(String additionalPrefixesConf) {
-    customVolumePrefix = new HashSet<>();
-    customVolumePrefix.addAll(CUSTOM_VOLUME_PREFIX);
+  private void prepareCustomVolumePrefixes(String additionalPrefixesConf) {
+    customVolumePrefixes = new HashSet<>();
+    customVolumePrefixes.addAll(CUSTOM_VOLUME_PREFIX);
     if (additionalPrefixesConf != null && !additionalPrefixesConf.isEmpty()) {
-      customVolumePrefix.addAll(
+      customVolumePrefixes.addAll(
         Arrays.stream(additionalPrefixesConf.split(",")).map(String::trim).collect(Collectors.toList()));
     }
   }

--- a/cdap-kubernetes/src/main/java/io/cdap/cdap/master/environment/k8s/KubeMasterEnvironment.java
+++ b/cdap-kubernetes/src/main/java/io/cdap/cdap/master/environment/k8s/KubeMasterEnvironment.java
@@ -107,6 +107,8 @@ public class KubeMasterEnvironment implements MasterEnvironment {
   // Contains the list of configuration / secret names coming from the Pod information, which are
   // needed to propagate to deployments created via the KubeTwillRunnerService
   private static final Set<String> CONFIG_NAMES = ImmutableSet.of("cdap-conf", "hadoop-conf", "cdap-security");
+
+  // default prefixes for custom ConfigMap and Secret volumes
   private static final Set<String> CUSTOM_VOLUME_PREFIX = ImmutableSet.of("cdap-cm-vol-", "cdap-se-vol-");
 
   private static final String MASTER_MAX_INSTANCES = "master.service.max.instances";
@@ -129,6 +131,7 @@ public class KubeMasterEnvironment implements MasterEnvironment {
   private static final String SPARK_KUBERNETES_DRIVER_LABEL_PREFIX = "spark.kubernetes.driver.label.";
   private static final String SPARK_KUBERNETES_EXECUTOR_LABEL_PREFIX = "spark.kubernetes.executor.label.";
   private static final String SPARK_KUBERNETES_NAMESPACE = "spark.kubernetes.namespace";
+  private static final String POD_ADDITIONAL_CUSTOM_VOLUME_PREFIXES = "k8s.pod.volume.additional_prefixes";
   @VisibleForTesting
   static final String SPARK_KUBERNETES_DRIVER_POD_TEMPLATE = "spark.kubernetes.driver.podTemplateFile";
   @VisibleForTesting
@@ -228,6 +231,7 @@ public class KubeMasterEnvironment implements MasterEnvironment {
   private long workloadIdentityServiceAccountTokenTTLSeconds;
   private String programCpuMultiplier;
   private String cdapInstallNamespace;
+  private Set<String> customVolumePrefix;
 
   public KubeMasterEnvironment() {
     gson = new Gson();
@@ -246,6 +250,7 @@ public class KubeMasterEnvironment implements MasterEnvironment {
     podUidFile = new File(podInfoDir, conf.getOrDefault(POD_UID_FILE, DEFAULT_POD_UID_FILE));
     podNamespaceFile = new File(podInfoDir, conf.getOrDefault(POD_NAMESPACE_FILE, DEFAULT_POD_NAMESPACE_FILE));
     workloadIdentityEnabled = Boolean.parseBoolean(conf.get(WORKLOAD_IDENTITY_ENABLED));
+    prepareCustomVolumePrefix(conf.get(POD_ADDITIONAL_CUSTOM_VOLUME_PREFIXES));
     String workloadIdentityProvider = null;
     if (workloadIdentityEnabled) {
       // Validate all workload identity configurations are set
@@ -582,7 +587,7 @@ public class KubeMasterEnvironment implements MasterEnvironment {
    * Returns {@code true} if the given volume name is prefixed with the custom volume mapping from the CRD.
    */
   private boolean isCustomVolumePrefix(String name) {
-    return CUSTOM_VOLUME_PREFIX.stream().anyMatch(name::startsWith);
+    return customVolumePrefix.stream().anyMatch(name::startsWith);
   }
 
   /**
@@ -868,6 +873,15 @@ public class KubeMasterEnvironment implements MasterEnvironment {
       .collect(Collectors.joining(","));
 
     return new PodWatcherThread(podInfo.getNamespace(), labelSelector);
+  }
+
+  private void prepareCustomVolumePrefix(String additionalPrefixesConf) {
+    customVolumePrefix = new HashSet<>();
+    customVolumePrefix.addAll(CUSTOM_VOLUME_PREFIX);
+    if (additionalPrefixesConf != null && !additionalPrefixesConf.isEmpty()) {
+      customVolumePrefix.addAll(
+        Arrays.stream(additionalPrefixesConf.split(",")).map(String::trim).collect(Collectors.toList()));
+    }
   }
 
   private static class PodWatcherThread extends AbstractWatcherThread<V1Pod> implements SparkDriverWatcher {

--- a/cdap-kubernetes/src/test/java/io/cdap/cdap/master/environment/k8s/KubeMasterEnvironmentTest.java
+++ b/cdap-kubernetes/src/test/java/io/cdap/cdap/master/environment/k8s/KubeMasterEnvironmentTest.java
@@ -42,6 +42,8 @@ import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -59,6 +61,9 @@ public class KubeMasterEnvironmentTest {
 
   private static final String KUBE_NAMESPACE = "test-kube-namespace";
   private static final String KUBE_INSTALL_NAMESPACE = "kube-install-namespace";
+
+  private static final String PREPARE_CUSTOM_VOLUME_PREFIX_METHOD_NAME = "prepareCustomVolumePrefix";
+  private static final String IS_CUSTOM_VOLUME_PREFIX_METHOD_NAME = "isCustomVolumePrefix";
 
   private CoreV1Api coreV1Api;
   private KubeMasterEnvironment kubeMasterEnvironment;
@@ -246,6 +251,54 @@ public class KubeMasterEnvironmentTest {
     gotName = KubeMasterEnvironment.getComponentName(
       "dap", "cdap-dap-preview-runner-b5786a15-e8f4-47-0cebad7d67-0");
     Assert.assertEquals("preview-runner-b5786a15-e8f4-47-0cebad7d67-0", gotName);
+  }
+
+  @Test
+  public void testSingleCustomVolume() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+    Method prepareCustomVolumePrefixMethod =
+      KubeMasterEnvironment.class.getDeclaredMethod(PREPARE_CUSTOM_VOLUME_PREFIX_METHOD_NAME, String.class);
+    prepareCustomVolumePrefixMethod.setAccessible(true);
+    Method isCustomVolumePrefixMethod =
+      KubeMasterEnvironment.class.getDeclaredMethod(IS_CUSTOM_VOLUME_PREFIX_METHOD_NAME, String.class);
+    isCustomVolumePrefixMethod.setAccessible(true);
+
+    prepareCustomVolumePrefixMethod.invoke(kubeMasterEnvironment, "test-av-");
+
+    // default ConfigMap and Secret volumes
+    Assert.assertTrue((boolean) isCustomVolumePrefixMethod.invoke(kubeMasterEnvironment, "cdap-cm-vol-vol1"));
+    Assert.assertTrue((boolean) isCustomVolumePrefixMethod.invoke(kubeMasterEnvironment, "cdap-se-vol-vol2"));
+
+    // required volumes
+    Assert.assertTrue((boolean) isCustomVolumePrefixMethod.invoke(kubeMasterEnvironment, "test-av-volume"));
+    Assert.assertTrue((boolean) isCustomVolumePrefixMethod.invoke(kubeMasterEnvironment, "test-av-logs"));
+
+    // not required volumes
+    Assert.assertFalse((boolean) isCustomVolumePrefixMethod.invoke(kubeMasterEnvironment, "test-bv-volume"));
+    Assert.assertFalse((boolean) isCustomVolumePrefixMethod.invoke(kubeMasterEnvironment, "test-cv-volume"));
+  }
+
+  @Test
+  public void testMultipleCustomVolumes() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+    Method prepareCustomVolumePrefixMethod =
+      KubeMasterEnvironment.class.getDeclaredMethod(PREPARE_CUSTOM_VOLUME_PREFIX_METHOD_NAME, String.class);
+    prepareCustomVolumePrefixMethod.setAccessible(true);
+    Method isCustomVolumePrefixMethod =
+      KubeMasterEnvironment.class.getDeclaredMethod(IS_CUSTOM_VOLUME_PREFIX_METHOD_NAME, String.class);
+    isCustomVolumePrefixMethod.setAccessible(true);
+
+    prepareCustomVolumePrefixMethod.invoke(kubeMasterEnvironment, "test-av-,test-bv-");
+
+    // default ConfigMap and Secret volumes
+    Assert.assertTrue((boolean) isCustomVolumePrefixMethod.invoke(kubeMasterEnvironment, "cdap-cm-vol-vol1"));
+    Assert.assertTrue((boolean) isCustomVolumePrefixMethod.invoke(kubeMasterEnvironment, "cdap-se-vol-vol2"));
+
+    // required volumes
+    Assert.assertTrue((boolean) isCustomVolumePrefixMethod.invoke(kubeMasterEnvironment, "test-av-volume"));
+    Assert.assertTrue((boolean) isCustomVolumePrefixMethod.invoke(kubeMasterEnvironment, "test-av-logs"));
+    Assert.assertTrue((boolean) isCustomVolumePrefixMethod.invoke(kubeMasterEnvironment, "test-bv-volume"));
+
+    // not required volumes
+    Assert.assertFalse((boolean) isCustomVolumePrefixMethod.invoke(kubeMasterEnvironment, "test-cv-volume"));
   }
 
   private void assertDoesNotMountWorkloadIdentityVolume(V1Pod driverPod, V1Pod executorPod) {

--- a/cdap-kubernetes/src/test/java/io/cdap/cdap/master/environment/k8s/KubeMasterEnvironmentTest.java
+++ b/cdap-kubernetes/src/test/java/io/cdap/cdap/master/environment/k8s/KubeMasterEnvironmentTest.java
@@ -62,7 +62,7 @@ public class KubeMasterEnvironmentTest {
   private static final String KUBE_NAMESPACE = "test-kube-namespace";
   private static final String KUBE_INSTALL_NAMESPACE = "kube-install-namespace";
 
-  private static final String PREPARE_CUSTOM_VOLUME_PREFIX_METHOD_NAME = "prepareCustomVolumePrefix";
+  private static final String PREPARE_CUSTOM_VOLUME_PREFIXES_METHOD_NAME = "prepareCustomVolumePrefixes";
   private static final String IS_CUSTOM_VOLUME_PREFIX_METHOD_NAME = "isCustomVolumePrefix";
 
   private CoreV1Api coreV1Api;
@@ -255,14 +255,14 @@ public class KubeMasterEnvironmentTest {
 
   @Test
   public void testSingleCustomVolume() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
-    Method prepareCustomVolumePrefixMethod =
-      KubeMasterEnvironment.class.getDeclaredMethod(PREPARE_CUSTOM_VOLUME_PREFIX_METHOD_NAME, String.class);
-    prepareCustomVolumePrefixMethod.setAccessible(true);
+    Method prepareCustomVolumePrefixesMethod =
+      KubeMasterEnvironment.class.getDeclaredMethod(PREPARE_CUSTOM_VOLUME_PREFIXES_METHOD_NAME, String.class);
+    prepareCustomVolumePrefixesMethod.setAccessible(true);
     Method isCustomVolumePrefixMethod =
       KubeMasterEnvironment.class.getDeclaredMethod(IS_CUSTOM_VOLUME_PREFIX_METHOD_NAME, String.class);
     isCustomVolumePrefixMethod.setAccessible(true);
 
-    prepareCustomVolumePrefixMethod.invoke(kubeMasterEnvironment, "test-av-");
+    prepareCustomVolumePrefixesMethod.invoke(kubeMasterEnvironment, "test-av-");
 
     // default ConfigMap and Secret volumes
     Assert.assertTrue((boolean) isCustomVolumePrefixMethod.invoke(kubeMasterEnvironment, "cdap-cm-vol-vol1"));
@@ -278,15 +278,16 @@ public class KubeMasterEnvironmentTest {
   }
 
   @Test
-  public void testMultipleCustomVolumes() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
-    Method prepareCustomVolumePrefixMethod =
-      KubeMasterEnvironment.class.getDeclaredMethod(PREPARE_CUSTOM_VOLUME_PREFIX_METHOD_NAME, String.class);
-    prepareCustomVolumePrefixMethod.setAccessible(true);
+  public void testMultipleCustomVolumes()
+    throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+    Method prepareCustomVolumePrefixesMethod =
+      KubeMasterEnvironment.class.getDeclaredMethod(PREPARE_CUSTOM_VOLUME_PREFIXES_METHOD_NAME, String.class);
+    prepareCustomVolumePrefixesMethod.setAccessible(true);
     Method isCustomVolumePrefixMethod =
       KubeMasterEnvironment.class.getDeclaredMethod(IS_CUSTOM_VOLUME_PREFIX_METHOD_NAME, String.class);
     isCustomVolumePrefixMethod.setAccessible(true);
 
-    prepareCustomVolumePrefixMethod.invoke(kubeMasterEnvironment, "test-av-,test-bv-");
+    prepareCustomVolumePrefixesMethod.invoke(kubeMasterEnvironment, "test-av-,test-bv-");
 
     // default ConfigMap and Secret volumes
     Assert.assertTrue((boolean) isCustomVolumePrefixMethod.invoke(kubeMasterEnvironment, "cdap-cm-vol-vol1"));


### PR DESCRIPTION
Added ability to forward volumes with specified prefixes from parent pods to child pods. New CDAP property "k8s.pod.volume.additional_prefixes" is used for that. This property supports supports multiple values separated by commas.

It was decided don't change CUSTOM_VOLUME_PREFIX constant name for the case if it is used externally via java reflection.